### PR TITLE
Serialization, changes and bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,10 @@ run/
 
 # Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
 !gradle-wrapper.jar
+
+# eclipse
+.classpath
+.project
+.settings/
+bin/
+*.launch

--- a/src/main/java/com/mag/queuemod/Mixins/AccessorLevelStorage.java
+++ b/src/main/java/com/mag/queuemod/Mixins/AccessorLevelStorage.java
@@ -1,0 +1,13 @@
+package com.mag.queuemod.Mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.level.storage.LevelStorageSource;
+
+@Mixin(MinecraftServer.class)
+public interface AccessorLevelStorage {
+	@Accessor
+	public LevelStorageSource.LevelStorageAccess getStorageSource();
+}

--- a/src/main/java/com/mag/queuemod/Mixins/MixinBarterInjection.java
+++ b/src/main/java/com/mag/queuemod/Mixins/MixinBarterInjection.java
@@ -13,18 +13,18 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import java.util.List;
 
 /**
- * Mixin to inject Trade from the bartering queue into the loot generation method in PiglinAi.class
+ * Mixin to inject Trade from the bartering queue into the loot generation
+ * method in PiglinAi.class
  */
 @Mixin(PiglinAi.class)
 public abstract class MixinBarterInjection {
 
-    @Inject( at = @At("RETURN"), method = "getBarterResponseItems", cancellable = true)
-    private static void injectItemStack(Piglin piglin, CallbackInfoReturnable<List<ItemStack>> cir){
-        int index = BarteringManager.getCounter();
-        if(index < BarteringManager.getQueueSize() && BarteringManager.isBarteringEnabled()){
-            cir.setReturnValue(BarteringManager.getTradeAsList(index));
-            BarteringManager.incrementCounter();
-            Queue.LOGGER.info("Injected Barter Item");
-        }
-    }
+	@Inject(at = @At("RETURN"), method = "getBarterResponseItems", cancellable = true)
+	private static void injectItemStack(Piglin piglin, CallbackInfoReturnable<List<ItemStack>> cir) {
+		List<ItemStack> injectedItem = BarteringManager.getTradeAsList();
+		if (injectedItem != null) {
+			cir.setReturnValue(injectedItem);
+			Queue.LOGGER.info("Injected Barter Item: {}", injectedItem.get(0));
+		}
+	}
 }

--- a/src/main/java/com/mag/queuemod/Mixins/MixinMinecraftServer.java
+++ b/src/main/java/com/mag/queuemod/Mixins/MixinMinecraftServer.java
@@ -1,0 +1,29 @@
+package com.mag.queuemod.Mixins;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import com.mag.queuemod.core.Events;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Creates hooks when starting and stopping the server
+ * @author Scribble
+ *
+ */
+@Mixin(MinecraftServer.class)
+public class MixinMinecraftServer {
+	
+	@Inject(method = "runServer", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/MinecraftServer;updateStatusIcon(Lnet/minecraft/network/protocol/status/ServerStatus;)V"))
+	public void inject_init(CallbackInfo ci) {
+		Events.onStartServer((MinecraftServer)(Object)this);
+	}
+	
+	@Inject(method = "stopServer", at = @At("HEAD"))
+	public void inject_stopServer(CallbackInfo ci) {
+		Events.onStopServer((MinecraftServer)(Object)this);
+	}
+}

--- a/src/main/java/com/mag/queuemod/Queue.java
+++ b/src/main/java/com/mag/queuemod/Queue.java
@@ -17,4 +17,5 @@ public class Queue implements ModInitializer {
         LOGGER.info("Bartering Manip Mod Initialised");
         LOGGER.info("Bartering Queue is enabled");
     }
+    
 }

--- a/src/main/java/com/mag/queuemod/core/BarteringManager.java
+++ b/src/main/java/com/mag/queuemod/core/BarteringManager.java
@@ -1,61 +1,224 @@
 package com.mag.queuemod.core;
 
-import lombok.Getter;
-import lombok.Setter;
-import net.minecraft.world.item.Item;
-import net.minecraft.world.item.ItemStack;
-
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.apache.commons.io.FileUtils;
+
+import com.mag.queuemod.Queue;
+import com.mag.queuemod.Mixins.AccessorLevelStorage;
+
+import lombok.Getter;
+import lombok.Setter;
+import net.minecraft.ChatFormatting;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
 
 /**
  * Class to manage the bartering queue. Has functions to add, clear, and get trades from the queue
  */
 public class BarteringManager {
-    private static final List<Trades> barteringTradeQueue = new ArrayList<>();
-    @Getter
-    private static final Trades[] tradesList = Trades.values();
+	/**
+	 * The main bartering queue that gets polled when a piglin desires a trade.
+	 */
+    private static final ConcurrentLinkedQueue<Trades> barteringTradeQueue = new ConcurrentLinkedQueue<>();
+    /**
+     * The finished trades list, filled once the trades from the bartering queue have succeeded. Can be emptied per element
+     */
+    private static final ConcurrentLinkedQueue<Trades> finishedTradeQueue = new ConcurrentLinkedQueue<>();
+    
+    public static MinecraftServer server;
+    
     @Setter @Getter
     private static boolean isBarteringEnabled = true;
-    @Getter
-    private static int counter = 0;
+    
     public static void addTrade(Trades trade){
         barteringTradeQueue.add(trade);
+        finishedTradeQueue.poll(); // Remove a finished trade once a new trade has been added
+        saveToFile();
     }
+    
     public static int getQueueSize(){
         return barteringTradeQueue.size();
     }
-    public static Trades getTrade(int index){
-        return barteringTradeQueue.get(index);
-    }
-
+    
     /**
      * This part is implemented like this instead of directly passing the ItemStack because from the enum because when 3 or more piglins trade together, the enum ItemStack is getting overwritten by Air
      * @param index the index for the trade
-     * @return Trade ItemStack wrapped in a List
+     * @return Trade ItemStack wrapped in a List or null if empty or disabled
      */
-    public static List<ItemStack> getTradeAsList(int index){
+    public static List<ItemStack> getTradeAsList(){
+    	
+    	if(!isBarteringEnabled) {	// Bartering is not enabled
+    		return null;
+    	}
+    	
         //Thanks to Scribble for this idea.
-        Trades trade = barteringTradeQueue.get(index);
+        Trades trade = barteringTradeQueue.poll();
+        if(trade == null) {
+        	return null;
+        }
+        
+        List<ItemStack> itemList = new ArrayList<>();
         switch(trade){
 //            case POTION_OF_FIRE_RESISTANCE, SPLASH_POTION_OF_FIRE_RESISTANCE, SOUL_SPEED_BOOK, SOUL_SPEED_BOOTS:
             case POTION_OF_FIRE_RESISTANCE:
             case SPLASH_POTION_OF_FIRE_RESISTANCE:
             case SOUL_SPEED_BOOTS:
             case SOUL_SPEED_BOOK:
-                return Collections.singletonList(trade.barterItem);
+            	itemList =  Collections.singletonList(trade.barterItem);
+            	break;
             default:
                 Item tradeItem = trade.barterItem.getItem();
                 int count = trade.barterItem.getCount();
-                return Collections.singletonList(new ItemStack(tradeItem, count));
+                itemList = Collections.singletonList(new ItemStack(tradeItem, count));
+                break;
         }
+        finishedTradeQueue.add(trade);
+        saveToFile();
+        return itemList;
     }
-    public static void incrementCounter(){
-        counter++;
-    }
+    
+    /**
+     * Resets finished queue and bartering queue
+     */
     public static void resetQueue(){
         barteringTradeQueue.clear();
-        counter = 0;
+        finishedTradeQueue.clear();
+        saveToFile();
+    }
+    
+    /**
+     * @return The trades in the bartering queue with formatting
+     */
+    public static String barterQueueToString() {
+    	String out="";
+    	Iterator<Trades> iterator = barteringTradeQueue.iterator();
+    	
+    	int counter = finishedTradeQueue.size(); // Start at the finished trades
+    	
+    	while (iterator.hasNext()) {
+			Trades trade = (Trades) iterator.next();
+			counter++;
+			out = out.concat(String.format(ChatFormatting.WHITE+"%s."+ ChatFormatting.DARK_AQUA+" %s %s\n", 
+					counter, 	// Replacement for the first %s in String.format
+					trade, 		// The second %s...
+					counter==finishedTradeQueue.size()+1 ?					// if counter==finishedTrades.size()+1
+							ChatFormatting.YELLOW+"\u21E0 Next Trade" 	// then do this
+							:""));										// else return an empty string
+		}
+    	return out;
+    }
+    
+    /**
+     * @return The trades in the finished trade queue with formatting
+     */
+    public static String finishedQueueToString() {
+    	String out="";
+    	Iterator<Trades> iterator = finishedTradeQueue.iterator();
+    	
+    	int counter = 0;
+    	
+    	while (iterator.hasNext()) {
+    		Trades finishedTrade = (Trades) iterator.next();
+			counter++;
+			out = out.concat(String.format(ChatFormatting.WHITE+"%s." + ChatFormatting.RED + " %s\n", counter, finishedTrade));
+    	}
+    	return out;
+    }
+    
+    /**
+     * Saves the current queue to saves/worldname/barteringQueue.txt
+     */
+    private static void saveToFile() {
+    	
+		List<String> linesToSave = new ArrayList<>();
+
+		// Convert queue to a list of lines
+		Iterator<Trades> iterator = barteringTradeQueue.iterator();
+		while (iterator.hasNext()) {
+			Trades trade = (Trades) iterator.next();
+			linesToSave.add(trade.toString());
+		}
+    	
+		// Create the file
+		File file;
+		try {
+			file = getSaveFile();
+		} catch (Exception e1) {
+			e1.printStackTrace();
+			return;
+		}
+
+
+		// Delete the file if it exists
+		if (file.exists())
+			file.delete();
+
+		// Write
+		try {
+			FileUtils.writeLines(file, StandardCharsets.UTF_8.toString(), linesToSave);
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
+    }
+    
+    /**
+     * loads the queue from saves/worldname/barteringQueue.txt
+     */
+    public static void loadSaveFile() {
+    	
+		if (server == null) {
+			Queue.LOGGER.error("Server is null!");
+			return;
+		}
+		
+		// Create the file
+		File file;
+		try {
+			file = getSaveFile();
+		} catch (Exception e1) {
+			e1.printStackTrace();
+			return;
+		}
+
+		if(!file.exists()) {
+			Queue.LOGGER.warn("barteringQueue.txt doesn't exist, ignoring it");
+			return;
+		}
+		
+		List<String> lines = new ArrayList<>();
+    	
+    	// Read!
+    	try {
+			lines = FileUtils.readLines(file, StandardCharsets.UTF_8);
+		} catch (IOException e) {
+			e.printStackTrace();
+			return;
+		}
+    	
+    	for(String line : lines) {
+    		Trades trade = Trades.fromString(line);
+    		if(trade==null)
+    			continue;
+    		barteringTradeQueue.add(trade);
+    	}
+    }
+    
+    private static File getSaveFile() throws Exception {
+		if (server == null) {
+			throw new Exception("The server is null!");
+		}
+    	// Get the world folder name from the minecraft server
+		String worldFolderName = ((AccessorLevelStorage) server).getStorageSource().getLevelId();
+		
+    	return new File(server.getServerDirectory(), (server.isDedicatedServer() ? "" : "/saves/") + worldFolderName + "/barteringQueue.txt");
     }
 }

--- a/src/main/java/com/mag/queuemod/core/BarteringManager.java
+++ b/src/main/java/com/mag/queuemod/core/BarteringManager.java
@@ -204,6 +204,9 @@ public class BarteringManager {
 			return;
 		}
     	
+    	barteringTradeQueue.clear();
+    	finishedTradeQueue.clear();
+    	
     	for(String line : lines) {
     		Trades trade = Trades.fromString(line);
     		if(trade==null)

--- a/src/main/java/com/mag/queuemod/core/Events.java
+++ b/src/main/java/com/mag/queuemod/core/Events.java
@@ -1,0 +1,36 @@
+package com.mag.queuemod.core;
+
+import com.mag.queuemod.Queue;
+import com.mag.queuemod.Mixins.MixinMinecraftServer;
+
+import net.minecraft.server.MinecraftServer;
+
+/**
+ * Various events
+ * 
+ * @author Scribble
+ *
+ */
+public class Events {
+	
+	/**
+	 * Called when the minecraft server is started
+	 * @param server The server variable when it's initialised
+	 * @see MixinMinecraftServer#inject_init(org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
+	 */
+	public static void onStartServer(MinecraftServer server) {
+		Queue.LOGGER.info("Calling event on start server");
+		BarteringManager.server = server;
+		BarteringManager.loadSaveFile();
+	}
+
+	/**
+	 * Called when the minecraft server is stopped
+	 * @param server The server variable when it's stopped
+	 * @see MixinMinecraftServer#inject_stopServer(org.spongepowered.asm.mixin.injection.callback.CallbackInfo)
+	 */
+	public static void onStopServer(MinecraftServer server) {
+		Queue.LOGGER.info("Calling event on stop server");
+		BarteringManager.server = null;
+	}
+}

--- a/src/main/java/com/mag/queuemod/core/Trades.java
+++ b/src/main/java/com/mag/queuemod/core/Trades.java
@@ -65,4 +65,18 @@ public enum Trades {
             Queue.LOGGER.info("Complex Items Loaded");
         }
     }
+    
+    @Override
+    public String toString() {
+    	return name;
+    }
+    
+    public static Trades fromString(String name) {
+    	for (Trades trade : values()) {
+			if(trade.name.equals(name)) {
+				return trade;
+			}
+		}
+    	return null;
+    }
 }

--- a/src/main/resources/queue.mixins.json
+++ b/src/main/resources/queue.mixins.json
@@ -5,7 +5,11 @@
   "compatibilityLevel": "JAVA_8",
   "mixins": [
     "MixinBarterInjection",
-    "MixinCommandRegistration"
+    "MixinCommandRegistration",
+    
+    "MixinMinecraftServer",	// Used for events on the server side
+    "AccessorLevelStorage"	// Used for getting the name of the world folder
+    
   ],
   "client": [
   ],


### PR DESCRIPTION
# New things
## Serialization
The bartering queue is now stored to a file in barteringQueue.txt. This is so you can make savestates together with the bartering queue, without manually readding items to the queue, once you load the savestate

The queue is saved every time items are added, an item is retrieved by the piglin or the queue is cleared. It is loaded everytime the server is started

## The finished trades disappear when adding a new items to the queue
While it's interesting to see the finished trades, it may be quite annoying when having to reset the queue... So as an example I made it so, when adding new items to the queue the newest item in the finished trades will be deleted... can easily be reverted if things are too annoying
# Changes
- Changed type of `barteringTradeQueue` from ArrayList to ConcurrentLinkedQueue
- Split `barteringTradeQueue` into `tradeQueue` and `finishedTradeQueue`
- Moved string list generation of `/bartering_queue show` to BarteringManager
- Remove `enable`/`disable` literal and added a `toggle` literal instead
# Bug fixes
- You can input negative values when adding new items
- `/bartering_queue show` sometimes throws index out of bounds exception